### PR TITLE
Add auto activation of Python in terminal

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,6 +37,8 @@
 						"source.fixAll": "explicit"
 					}
 				},
+				"python.terminal.activateEnvInCurrentTerminal": true,
+				"python.terminal.activateEnvironment": true,
 				// ___ Mypy settings ___
 				"mypy-type-checker.reportingScope": "workspace",
 				"mypy-type-checker.preferDaemon": true,


### PR DESCRIPTION
This pull request adds the feature to automatically activate the Python environment in the terminal. This will make it easier for developers to work with Python projects by automatically activating the correct environment without manual intervention.